### PR TITLE
Homepage showcase external url links

### DIFF
--- a/ckanext/showcase/logic/helpers.py
+++ b/ckanext/showcase/logic/helpers.py
@@ -47,3 +47,11 @@ def get_package_showcase_list(package_id):
     except:
         return []
     return showcases
+
+def get_showcase_package_list(showcase_id):
+    packages = []
+    try:
+        packages = tk.get_action('ckanext_showcase_package_list')({},{'showcase_id':showcase_id})
+    except:
+        return []
+    return packages

--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -99,7 +99,8 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
             'facet_remove_field': showcase_helpers.facet_remove_field,
             'get_site_statistics': showcase_helpers.get_site_statistics,
             'get_recent_showcase_list': showcase_helpers.get_recent_showcase_list,
-            'get_package_showcase_list': showcase_helpers.get_package_showcase_list
+            'get_package_showcase_list': showcase_helpers.get_package_showcase_list,
+            'get_showcase_package_list': showcase_helpers.get_showcase_package_list
         }
 
     # IFacets

--- a/ckanext/showcase/templates/home/snippets/showcase_item.html
+++ b/ckanext/showcase/templates/home/snippets/showcase_item.html
@@ -28,7 +28,11 @@ show_remove    - If True, show the remove button to remove showcase/dataset asso
       <h3>{{ showcase.title }}</h3>
     {% endblock %}
     {% block link %}
-      {% set showcase_url = showcase.url or h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=showcase.name) %}
+      {% if h.get_showcase_package_list(showcase.id) %}
+        {% set showcase_url = h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=showcase.name) %}
+      {% else %}
+        {% set showcase_url = showcase.url or h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=showcase.name) %}
+      {% endif %}
       <a class="media-view" href="{{ showcase_url }}" title="{{ _('View {name}').format(name=showcase.title) }}" target="_blank">
         <span>{{ _('View {name}').format(name=showcase.title) }}</span>
       </a>


### PR DESCRIPTION
Showcase links on the homepage should link to external url if an external url is set and if there are no datasets associated with that showcase.