### PR TITLE
[OD-1016] Add option to redirect to external link

### DIFF
--- a/ckanext/showcase/logic/helpers.py
+++ b/ckanext/showcase/logic/helpers.py
@@ -48,10 +48,9 @@ def get_package_showcase_list(package_id):
         return []
     return showcases
 
-def get_showcase_package_list(showcase_id):
-    packages = []
-    try:
-        packages = tk.get_action('ckanext_showcase_package_list')({},{'showcase_id':showcase_id})
-    except:
-        return []
-    return packages
+def get_value_from_showcase_extras(extras, key):
+    value = ''
+    for item in extras:
+        if item.get('key') == key:
+            value = item.get('value')
+    return value

--- a/ckanext/showcase/logic/schema.py
+++ b/ckanext/showcase/logic/schema.py
@@ -47,6 +47,9 @@ def showcase_base_schema():
                       toolkit.get_converter('convert_to_extras')],
         'original_related_item_id': [
             toolkit.get_validator('ignore_missing'),
+            toolkit.get_converter('convert_to_extras')],
+        'redirect_link': [
+            toolkit.get_validator('ignore_missing'),
             toolkit.get_converter('convert_to_extras')]
     }
     return schema
@@ -108,6 +111,9 @@ def showcase_show_schema():
         'image_url': [toolkit.get_converter('convert_from_extras'),
                       toolkit.get_validator('ignore_missing')],
         'original_related_item_id': [
+            toolkit.get_converter('convert_from_extras'),
+            toolkit.get_validator('ignore_missing')],
+        'redirect_link': [
             toolkit.get_converter('convert_from_extras'),
             toolkit.get_validator('ignore_missing')]
     })

--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -100,7 +100,7 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
             'get_site_statistics': showcase_helpers.get_site_statistics,
             'get_recent_showcase_list': showcase_helpers.get_recent_showcase_list,
             'get_package_showcase_list': showcase_helpers.get_package_showcase_list,
-            'get_showcase_package_list': showcase_helpers.get_showcase_package_list
+            'get_value_from_showcase_extras': showcase_helpers.get_value_from_showcase_extras
         }
 
     # IFacets
@@ -231,6 +231,9 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
         # Rendered notes
         pkg_dict[u'showcase_notes_formatted'] = \
             h.render_markdown(pkg_dict['notes'])
+
+        # Add redirect_link flag
+        pkg_dict[u'redirect_link'] = pkg_dict.get('redirect_link', False)
         return pkg_dict
 
     def after_show(self, context, pkg_dict):

--- a/ckanext/showcase/templates/header.html.bak
+++ b/ckanext/showcase/templates/header.html.bak
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block header_site_navigation_tabs %}
+  {{ h.build_nav_main(
+    ('search', _('Datasets')),
+    ('organizations_index', _('Organizations')),
+    ('group_index', _('Groups')),
+    ('ckanext_showcase_index', _('Showcases')),
+    ('about', _('About'))
+  ) }}
+{% endblock %}

--- a/ckanext/showcase/templates/home/snippets/showcase_item.html
+++ b/ckanext/showcase/templates/home/snippets/showcase_item.html
@@ -18,22 +18,24 @@ show_remove    - If True, show the remove button to remove showcase/dataset asso
 <div class="media-item">
   {% block item_inner %}
     {% block image %}
-      {% if showcase.extras[0].value and 'http' not in showcase.extras[0].value %}
-      <img data-lazy="/uploads/showcase/{{ showcase.extras[0].value }}" alt="" class="media-image">
+      {% set image_url = h.get_value_from_showcase_extras(showcase.extras, 'image_url') %}
+      {% if image_url and not image_url.startswith('http') %}
+      <img data-lazy="/uploads/showcase/{{ image_url }}" alt="" class="media-image">
       {% else %}
-      <img data-lazy="{{ showcase.extras[0].value or h.url_for_static('/base/images/placeholder-group.png') }}" alt="" class="media-image">
+      <img data-lazy="{{ image_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="" class="media-image">
       {% endif %}
     {% endblock %}
     {% block title %}
       <h3>{{ showcase.title }}</h3>
     {% endblock %}
     {% block link %}
-      {% if h.get_showcase_package_list(showcase.id) %}
-        {% set showcase_url = h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=showcase.name) %}
+      {% set redirect_link = h.get_value_from_showcase_extras(showcase.extras, 'redirect_link') %}
+      {% if redirect_link and showcase.url %}
+        {% set showcase_url = showcase.url %}
       {% else %}
-        {% set showcase_url = showcase.url or h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=showcase.name) %}
+        {% set showcase_url = h.url_for(controller='ckanext.showcase.controller:ShowcaseController', action='read', id=showcase.name) %}
       {% endif %}
-      <a class="media-view" href="{{ showcase_url }}" title="{{ _('View {name}').format(name=showcase.title) }}" target="_blank">
+      <a class="media-view" href="{{ showcase_url }}" title="{{ _('View {name}').format(name=showcase.title) }}" {% if redirect_link %}target="_blank"{% endif %}>
         <span>{{ _('View {name}').format(name=showcase.title) }}</span>
       </a>
     {% endblock %}

--- a/ckanext/showcase/templates/showcase/new_package_form.html
+++ b/ckanext/showcase/templates/showcase/new_package_form.html
@@ -42,6 +42,8 @@
   {% block metadata_fields %}
     {% block package_metadata_fields_url %}
       {{ form.input('url', label=_('External link'), id='field-url', placeholder=_('http://www.example.com'), value=data.url, error=errors.url, classes=['control-medium']) }}
+      {% set redirect_link_checked = data.redirect_link or false %}
+      {{ form.checkbox('redirect_link', label=_('Redirect to external link'), id='field-redirect-link', checked=redirect_link_checked, value=true, error=errors.redirect_link) }}
     {% endblock %}
 
     {% block package_metadata_author %}


### PR DESCRIPTION
## [Ticket](https://opengovinc.atlassian.net/browse/OD-1016)

## Description
The existing logic to determine if a showcase item on the homepage should redirect to an external url does not have good performance. Especially when there are dozens of showcase with many associated datasets.

This PR adds an option to the showcase form page to redirect to an external link. Showcase editors will decide if an external link should be redirected to instead of letting the extension figure it out.

## Testing
- Create a dozen showcases and associate each showcase with 3 or more datasets. The showcase can be associated with the same datasets.
- Go to the homepage and measure how long it takes to render the page. The CKAN log should indicate how long it takes.
- Install this PR without the OpenGov Stories extension. The OpenGov Stories will need a separate PR to add the checkbox.
- Go to a showcase and edit it. Below the External link field will be a checkbox to redirect to the external link.
- Enable the redirect using the checkbox and go to the homepage.
- Clicking on the showcase link should redirect users to the external link and not the showcase's page.
- The homepage should render faster compared to before the PR was installed.
