### PR TITLE
[OD-1144] Fix FontAwesome picture icon

### DIFF
--- a/ckanext/showcase/plugin.py
+++ b/ckanext/showcase/plugin.py
@@ -151,16 +151,16 @@ class ShowcasePlugin(plugins.SingletonPlugin, lib_plugins.DefaultDatasetForm):
             m.connect('ckanext_showcase_delete', '/showcase/delete/{id}',
                       action='delete')
             m.connect('ckanext_showcase_read', '/showcase/{id}', action='read',
-                      ckan_icon='picture')
+                      ckan_icon='picture-o')
             m.connect('ckanext_showcase_edit', '/showcase/edit/{id}',
                       action='edit', ckan_icon='edit')
             m.connect('ckanext_showcase_manage_datasets',
                       '/showcase/manage_datasets/{id}',
                       action="manage_datasets", ckan_icon="sitemap")
             m.connect('dataset_showcase_list', '/dataset/showcases/{id}',
-                      action='dataset_showcase_list', ckan_icon='picture')
+                      action='dataset_showcase_list', ckan_icon='picture-o')
             m.connect('ckanext_showcase_admins', '/ckan-admin/showcase_admins',
-                      action='manage_showcase_admins', ckan_icon='picture'),
+                      action='manage_showcase_admins', ckan_icon='picture-o'),
             m.connect('ckanext_showcase_admin_remove',
                       '/ckan-admin/showcase_admin_remove',
                       action='remove_showcase_admin')


### PR DESCRIPTION
## [Ticket](https://opengovinc.atlassian.net/browse/OD-1144)

## Description
The showcase extension is using the FontAwesome icon `picture`. However, in FontAwesome 4 the icon should be `picture-o`, since `picture` does not exist. https://fontawesome.com/v4.7.0/icon/picture-o

## Testing
- Install the showcase extension and checkout this PR
- Go to a dataset page and check that the showcase tab has an icon
![screen shot 2019-01-29 at 4 29 00 pm](https://user-images.githubusercontent.com/4096633/51941627-121dc500-23e3-11e9-9105-459f133229f3.png)
- As a sysadmin go to the admin page and check that the showcase config tab has an icon
![screen shot 2019-01-29 at 4 30 28 pm](https://user-images.githubusercontent.com/4096633/51941767-64f77c80-23e3-11e9-9a7d-ce4bb2d5133f.png)
