### PR TITLE
Change import of g to c from toolkit

### DIFF
--- a/ckanext/showcase/plugin/__init__.py
+++ b/ckanext/showcase/plugin/__init__.py
@@ -191,7 +191,7 @@ class ShowcasePlugin(
         '''
         Modify pkg_dict that is sent to templates.
         '''
-        context = {'user': tk.g.user or tk.g.author}
+        context = {'user': tk.c.user or tk.c.author}
 
         return self._add_to_pkg_dict(context, pkg_dict)
 


### PR DESCRIPTION
## Description
This PR changes the use of toolkit.g to toolkit.c
For ckan 2.10 it is preferred to use g over c.
However, this causes an import error from toolkit on earlier ckan versions.