### PR TITLE
Accessibility updates

### DIFF
--- a/ckanext/showcase/fanstatic/js/slick.js
+++ b/ckanext/showcase/fanstatic/js/slick.js
@@ -527,7 +527,7 @@ $(this).find("a").first().attr({
             _.$slides.wrapAll('<div class="slick-track"/>').parent();
 
         _.$list = _.$slideTrack.wrap(
-            '<div aria-live="polite" class="slick-list"/>').parent();
+            '<div class="slick-list"/>').parent();
         _.$slideTrack.css('opacity', 0);
 
         if (_.options.centerMode === true || _.options.swipeToSlide === true) {
@@ -2573,11 +2573,9 @@ $(this).find("a").first().attr({
             'tabindex': '-1'
         });
 
-        _.$slideTrack.attr('role', 'listbox');
-
         _.$slides.not(_.$slideTrack.find('.slick-cloned')).each(function(i) {
             $(this).attr({
-                'role': 'option',
+                'role': 'tabpanel',
                 'aria-labelledby': 'slick-slide' + _.instanceUid + i + ''
             });
             $(this).find("h3").first().attr({
@@ -2611,8 +2609,7 @@ $(this).find("a").first().attr({
         // _isSlideOnFocus = _.$slides.is(':focus') || _.$slides.find('*').is(':focus');
 
         _.$slideTrack.find('.slick-active').attr({
-            'aria-hidden': 'false',
-            'tabindex': '0'
+            'aria-hidden': 'false'
         }).find('a, input, button, select').attr({
             'tabindex': '0'
         });

--- a/ckanext/showcase/templates/showcase/snippets/showcase_info.html
+++ b/ckanext/showcase/templates/showcase/snippets/showcase_info.html
@@ -34,7 +34,7 @@ Example:
         </section>
 
         <section class="module module-narrow">
-            <h3 class="module-heading"><i class="fa fa-sitemap icon-medium icon-sitemap"></i> {{ _('Datasets in Showcase') }}</h2>
+            <h2 class="module-heading"><i class="fa fa-sitemap icon-medium icon-sitemap"></i> {{ _('Datasets in Showcase') }}</h2>
                 {% if showcase_pkgs %}
                     <ul class="nav nav-simple">
                         {% for package in showcase_pkgs %}


### PR DESCRIPTION
# Description
This PR has some accessibility updates for the showcase slider:
- Remove `aria-live="polite"` to reduce noise to screen readers
- Remove `listbox` role from slide-track
- Change role to `tabpanel` for slide as it's not an `option` in a `listbox`
- Remove `tabindex=0` from active slide as it causes double tabbing when navigating with keyboard
- Change h3 tag to h2 tag to fix heading ordering